### PR TITLE
Update config.pro to use api.pro.coinbase.com?

### DIFF
--- a/config/configPro.go
+++ b/config/configPro.go
@@ -1,0 +1,13 @@
+package config
+
+var (
+	BaseUrl string
+	Sandbox = false // set to true if you want to use the sandbox API endpoint
+)
+
+func init() {
+	BaseUrl = "https://api.pro.coinbase.com/v1/"
+	if Sandbox == true {
+		BaseUrl = "https://api.pro.sandbox.coinbase.com/v1/"
+	}
+}


### PR DESCRIPTION
"We encourage Coinbase Pro users to begin migrating their API usage away from api.gdax.com to api.pro.coinbase.com"

https://blog.coinbase.com/transition-to-coinbase-pro-db8f9b574ad2

Sorry, guys -- complete newb here.  If I could delete this I would.